### PR TITLE
[조예슬] 메인 상품 목록 api 구현 

### DIFF
--- a/products/views.py
+++ b/products/views.py
@@ -34,10 +34,6 @@ class ProductItemView(View):
 
 class ProductListView(View):
     def get(self, request):
-        summer_gift        = request.GET.get('summer-gift')
-        popular_gift       = request.GET.get('popular-gift')
-        time_sale          = request.GET.get('time-sale')
-        
         first_category_id  = request.GET.get('first-category', 1)
         second_category_id = request.GET.get('second-category')
         sort               = request.GET.get('sort', 'new-arrival')
@@ -45,23 +41,9 @@ class ProductListView(View):
 
         limit              = int(request.GET.get("limit", 10))
         offset             = int(request.GET.get("offset", 1))
-
-        queries = Q()
-
-        if summer_gift:
-            second_category_id = 5
-            limit              = 7
-            queries            = Q(title__contains='아이스')
-
-        elif popular_gift:
-            limit = 7
-            sort = 'discount'
-
-        elif time_sale:
-            sort = 'discount'
         
         if second_category_id:
-            queries &= Q(second_category = second_category_id)
+            queries = Q(second_category = second_category_id)
 
         elif first_category_id:
             queries = Q(second_category__first_category_id = first_category_id)
@@ -107,12 +89,5 @@ class ProductListView(View):
             'types'           : [type.name for type in page_item.types.all()]
         } for page_item in page_items]
 
-        if summer_gift or popular_gift:
-            return JsonResponse({'products': products}, status=200)
-        
-        elif time_sale:
-            return JsonResponse({'products' : products[0]})
-
-        else:    
-            return JsonResponse({'total' : total, 'products': products}, status=200)
+        return JsonResponse({'total' : total, 'products': products}, status=200)
         

--- a/products/views.py
+++ b/products/views.py
@@ -38,7 +38,6 @@ class ProductListView(View):
         second_category_id = request.GET.get('second-category')
         sort               = request.GET.get('sort', 'new-arrival')
         tea_types          = request.GET.getlist('type')
-
         limit              = int(request.GET.get("limit", 10))
         offset             = int(request.GET.get("offset", 1))
         


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 
- 할인율 기준으로 sort할 수 있게 기존 상품목록 api 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 쿼리 파라미터에 sort=discount를 사용하면 할인율 기준으로 상품을 정렬하여 보내주도록 수정했습니다.
2. 이제 메인 화면의 '이번 주 인기 선물', '오늘만 이 가격' 두 곳에서 sort=discount를 이용하여 해당 api를 호출할 수 있습니다.
3. '이번 주 인기 선물'에 해당하는 상품 리스트  
   - 엔드포인트 : /products/list?first-category=1&limit=7&sort=discount
   - 1차 카테고리 아이디가 1인 상품(티 제품) 중 할인율이 제일 높은 7개를 보내줍니다. (주문 api가 완료되지 않아 임의로 정했습니다.)

4. '오늘만 이 가격'에 해당하는 상품 리스트
   - 엔드포인트 : /products/list?first-category=1&limit=7&sort=discount
   - 전체 상품 중 할인율이 가장 높은 1개를 보내줍니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 화면 위주가 아니라 기능 위주로 api를 설계해야 한다는 것을 배웠습니다.
   - 처음에는 화면 위주로 생각해서 새로운 api를 제작하려고 했습니다.
   - 기능 위주로 생각하니 상품 목록 api로 모든 요청을 처리할 수 있었습니다.
   - 기능 위주로 설계해야 중복 없이 효율적인 설계를 할 수 있음을 알게 되었습니다.

- api 명세서를 작성해서 프론트엔드와 효과적으로 소통했습니다.
   - 가능한 쿼리 파라미터의 종류가 많고 복잡한데 명세서를 통해 소통하니 편리했습니다. 

<br />

## :: 기타 질문 및 특이 사항
- 상품 목록 화면에서 api를 호출했을 때는 type 정보를 전달해야 하지만 메인에서 api를 호출했을 때는 type 정보가 필요없다고 합니다. 코드가 너무 길어지는 것 같아서 두 경우 모두 type 정보를 전달하도록 만들었는데 이 경우 더 나은 처리 방법이 있나요?    